### PR TITLE
Modification de l'affichage du rang

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -71,14 +71,45 @@ function displayRank(allGrades) {
             return ;
         }
 
-        let p = document.createElement("p");
-        p.style.margin = "0px";
-        p.style.float = "left";
-        p.style.paddingLeft = "5px";
-        p.innerHTML = `${rank}/${grades.length} [${numberOfSameNotes}]`;
-        gradesDiv[i].parentNode.after(p);
+        // Create a new div element
+        let element = document.createElement("div");
+        element.className = "item";
+        
+        // Add the position and the percentage of the student
+        if (numberOfSameNotes > 1) {
+            element.innerHTML = `<div class='rank'>${rank+numberOfSameNotes-1}-${rank}/${grades.length}</div>
+                                 <div class='pourcent'>${Math.round((rank+numberOfSameNotes-1)/grades.length*10000)/100}-${Math.round(rank/grades.length*10000)/100}%</div>`
+
+        } else {
+            element.innerHTML = `<div class='rank'>${rank}/${grades.length}</div>
+                                 <div class='pourcent'>${Math.round(rank/grades.length*10000)/100}%</div>`
+        }
+
+        gradesDiv[i].parentNode.after(element);
     }
+
+    // Add the event listener to display the percentage
+    var items = document.querySelectorAll('.item');
+
+    items.forEach(function(item) {
+        let pourcent = item.querySelector('.pourcent');
+        let rank = item.querySelector('.rank');
+
+        // Hide the percentage by default
+        pourcent.style.display = 'none';
+
+        // Add the event listener
+        item.addEventListener('mouseover', function() {
+            pourcent.style.display = 'inline';
+            rank.style.display = 'none';
+        });
+        item.addEventListener('mouseout', function() {
+            pourcent.style.display = 'none';
+            rank.style.display = 'inline';
+        });
+    });
 }
+
 
 function getPersonnalRank(grades, studentGrade) {
     grades.sort(function(a,b) { return b - a;});


### PR DESCRIPTION
Je propose un affichage du rang qui me semble bien plus compréhensible pour le client final :

en cas d'égalité :
Avant : `68/138 [26]`
Après : `93-68/138`

en cas de note seule:
Avant : `68/138 [1]`
Après : `68/138`

cela permet à l'utilisateur de ne pas avoir à faire de calcul et il n'y a plus de confusion avec le `[1]` ou l'utilisateur peut se demander s'il est vraiment seul ou si cela lui précise qu'il est avec une autre personne

De plus, j'ai ajouté une information au survol de l'élément de rang afin d'afficher le pourcentage de positionnement de l'utilisateur. Cela lui permet notamment de savoir s'il se trouve dans le premier tiers de la promo ou bien à la moitié par exemple.

Exemple sans survol : `66-59/134`
Exemple avec survol : `49.25-44.03%`

malgré la longueur de la chaine de caractère, cela rentre bien dans le compartiment.